### PR TITLE
Add in-cluster support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ COMMIT=$(shell git rev-parse HEAD)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 GOVERSION=$(shell go version | awk -F\go '{print $$3}' | awk '{print $$1}')
 GITHUB_USERNAME=amimof
-BUILD_DIR=${GOPATH}/src/gitlab.com/${GITHUB_USERNAME}/${BINARY}
+BUILD_DIR=${GOPATH}/src/github.com/${GITHUB_USERNAME}/${BINARY}
 PKG_LIST=$$(go list ./... | grep -v /vendor/)
 # Setup the -ldflags option for go build here, interpolate the variable values
 LDFLAGS = -ldflags "-X main.VERSION=${VERSION} -X main.COMMIT=${COMMIT} -X main.BRANCH=${BRANCH} -X main.GOVERSION=${GOVERSION}"
@@ -45,25 +45,25 @@ windows: dep
 build: linux darwin rpi windows
 
 docker_fmt:
-	docker run --rm -v "${PWD}":/go/src/gitlab.com/amimof/logga -w /go/src/gitlab.com/amimof/logga golang:${GOVERSION} make fmt
+	docker run --rm -v "${PWD}":/go/src/github.com/amimof/logga -w /go/src/github.com/amimof/logga golang:${GOVERSION} make fmt
 
 docker_test:
-	docker run --rm -v "${PWD}":/go/src/gitlab.com/amimof/logga -w /go/src/gitlab.com/amimof/logga golang:${GOVERSION} make test
+	docker run --rm -v "${PWD}":/go/src/github.com/amimof/logga -w /go/src/github.com/amimof/logga golang:${GOVERSION} make test
 
 docker_compile:
-	docker run --rm -v "${PWD}":/go/src/gitlab.com/amimof/logga -w /go/src/gitlab.com/amimof/logga golang:${GOVERSION} make linux
+	docker run --rm -v "${PWD}":/go/src/github.com/amimof/logga -w /go/src/github.com/amimof/logga golang:${GOVERSION} make linux
 
 docker_npm_build:
-	docker run --rm -v "${PWD}":/go/src/gitlab.com/amimof/logga -w /go/src/gitlab.com/amimof/logga/web node:8 npm install
-	docker run --rm -v "${PWD}":/go/src/gitlab.com/amimof/logga -w /go/src/gitlab.com/amimof/logga/web node:8 npm run build
+	docker run --rm -v "${PWD}":/go/src/github.com/amimof/logga -w /go/src/github.com/amimof/logga/web node:8 npm install
+	docker run --rm -v "${PWD}":/go/src/github.com/amimof/logga -w /go/src/github.com/amimof/logga/web node:8 npm run build
 
 docker_image_build:
-	docker build -t registry.gitlab.com/amimof/logga:${VERSION} .
-	docker tag registry.gitlab.com/amimof/logga:${VERSION} registry.gitlab.com/amimof/logga:latest
+	docker build -t amimof/logga:${VERSION} .
+	docker tag amimof/logga:${VERSION} amimof/logga:latest
 
 docker_image_push:
-	docker push registry.gitlab.com/amimof/logga:${VERSION}
-	docker push registry.gitlab.com/amimof/logga:latest
+	docker push amimof/logga:${VERSION}
+	docker push amimof/logga:latest
 
 docker_build: docker_compile docker_npm_build docker_image_build docker_image_push
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ----
 
-logga is an easy to use and powerful container log dashboard for Kubernetes. It's used by application teams and sysadmins to effortlessly view container logs in a namespace using a web browser, without a complex logging infrastructure. Logga is ment to be deployed in Kubernetes per namespace by developers and uses in-cluster RBAC authorisation. Some of the key futures are:
+logga is an easy to use and powerful container log dashboard for [Kubernetes](https://kubernetes.io). It's used by application teams, developers and sysadmins to effortlessly view container logs in a namespace using a web browser, without a complex logging infrastructure. Logga is ment to be deployed in Kubernetes per namespace by developers and uses in-cluster RBAC authorisation. Some of the key futures are:
 
 * Super easy do deploy and manage
 * Fully stateless 
@@ -29,4 +29,4 @@ docker run -d --name logga -p 8080:8080 amimof/logga:latest
 
 ## Contributing
 
-All help in any form is highly appreciated and your are welcome participate in developing `Huego` together. To contribute submit a `Pull Request`. If you want to provide feedback, open up a Github `Issue` or contact me personally. 
+All help in any form is highly appreciated and your are welcome participate in developing `logga` together. To contribute submit a `Pull Request`. If you want to provide feedback, open up a Github `Issue` or contact me personally. 

--- a/deploy/kubernetes.yml
+++ b/deploy/kubernetes.yml
@@ -1,0 +1,86 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:   
+  name: logga
+rules:
+- apiGroups:
+  - ""        
+  resources:   
+  - namespaces
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: logga
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: logga
+subjects:
+- kind: ServiceAccount
+  name: logga
+  namespace: logging
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logga
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: logga
+  name: logga
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: logga
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: logga
+  name: logga
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: logga
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: logga
+    spec:
+      containers:
+      - args:
+        - --host=0.0.0.0
+        image: amimof/logga:latest
+        imagePullPolicy: Always
+        name: logga
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+      serviceAccount: logga
+      serviceAccountName: logga
+  

--- a/pkg/api/broker.go
+++ b/pkg/api/broker.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"log"
+	"time"
+)
+
+type Broker struct {
+	// Events are pushed to this channel by the main events-gathering routine
+	Notifier chan []byte
+
+	// New client connections
+	newClients chan chan []byte
+
+	// Closed client connections
+	closingClients chan chan []byte
+
+	// Client connections registry
+	clients map[chan []byte]bool
+}
+
+func NewBroker() *Broker {
+	broker := &Broker{
+		Notifier:       make(chan []byte, 1),
+		newClients:     make(chan chan []byte),
+		closingClients: make(chan chan []byte),
+		clients:        make(map[chan []byte]bool),
+	}
+	go broker.listen()
+	return broker
+}
+
+func (broker *Broker) listen() {
+	patience := time.Second * 1
+	for {
+		select {
+		case s := <-broker.newClients:
+
+			// A new client has connected.
+			// Register their message channel
+			broker.clients[s] = true
+			log.Printf("Client added. %d registered clients", len(broker.clients))
+		case s := <-broker.closingClients:
+
+			// A client has dettached and we want to
+			// stop sending them messages.
+			delete(broker.clients, s)
+			log.Printf("Removed client. %d registered clients", len(broker.clients))
+		case event := <-broker.Notifier:
+
+			// We got a new event from the outside!
+			// Send event to all connected clients
+			for clientMessageChan, _ := range broker.clients {
+				select {
+				case clientMessageChan <- event:
+				case <-time.After(patience):
+					//log.Print("Skipping client.")
+					continue
+				}
+			}
+		}
+	}
+
+}

--- a/pkg/api/broker_test.go
+++ b/pkg/api/broker_test.go
@@ -1,0 +1,1 @@
+package api_test


### PR DESCRIPTION
1. Logga will try to find a kubeconfig in `~/.kube/config`. Path can be overriden  with `--kubeconfig`.
2. Logga will fallback to use in-cluster config.
3. Logga errors out if the two above fails.